### PR TITLE
improve compatibility with Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ function timed<T>(what: string, f: () => T): T {
         if (options.printLlirOnly) {
             console.log(llir);
         } else {
-            const llpath = path.join(os.tmpdir(), `tmpir${Date.now}.ll`);
+            const llpath = path.join(os.tmpdir(), `tmpir${Date.now()}.ll`);
             fs.writeFileSync(llpath, llir);
             // TODO: don't use -Wno-override-module
             timed('clang', () => cProcess.spawnSync(`clang ${options.optLevel} -Wno-override-module ${llpath}`, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { addFileToSourceMap, createSourceMap, ppSpan } from './span';
 import { ppTy } from './ty';
 import { codegen } from './llvm';
 import path from 'path';
+import os from 'os';
 import { Bug, DiagError, emitErrorRaw } from './error';
 
 function timed<T>(what: string, f: () => T): T {
@@ -43,7 +44,7 @@ function timed<T>(what: string, f: () => T): T {
         if (options.printLlirOnly) {
             console.log(llir);
         } else {
-            const llpath = `/tmp/tmpir${Date.now()}.ll`;
+            const llpath = path.join(os.tmpdir(), `tmpir${Date.now}.ll`);
             fs.writeFileSync(llpath, llir);
             // TODO: don't use -Wno-override-module
             timed('clang', () => cProcess.spawnSync(`clang ${options.optLevel} -Wno-override-module ${llpath}`, {

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -23,6 +23,7 @@ export function tokenize(sm: SourceMap, file: File): Token[] {
 
         switch (src[i]) {
             case ' ':
+            case '\r':
             case '\n':
                 break;
             case '(': tokens.push({ span: [start, i + 1], ty: TokenType.LParen }); break;


### PR DESCRIPTION
This PR implements a few small changes to improve compatibility with Windows:

- Modify the tokeniser to ignore carriage return (`\r`) characters, fixing the lexing step
- Refer to an OS-Agnostic `os.tmpdir()` for tmpir.ll files, fixing the compiling step